### PR TITLE
Allow support for Zim wiki Tag highlighting

### DIFF
--- a/syntax/zimwiki.vim
+++ b/syntax/zimwiki.vim
@@ -14,7 +14,6 @@ syn match zimwikiHeader4 '^=\{3} .\+ =\{3}[[:space:]]*$'
 syn match zimwikiHeader5 '^=\{2} .\+ =\{2}[[:space:]]*$'
 
 syn match zimwikiLink '\[\[.\{-1,}\]\]'
-
 syn match zimwikiListItem '^[[:blank:]]*\* .\+'
 syn match zimwikiCheckbox '\[[ \*x]\]'
 syn match zimwikiStrong '\*\*.\{-1,}\*\*'
@@ -47,12 +46,9 @@ hi def link zimwikiStrikeThrough	Comment
 hi def link zimwikiImage	Float
 hi def link zimwikiSub	Number
 hi def link zimwikiSup	Number
-" hi! def link zimwikiTag Number
 hi! def link zimwikiTag PreProc
 
-
 hi def link zimwikiCode	SpecialComment
-
 
 if !exists('b:current_syntax')
   let b:current_syntax = 'zimwiki'

--- a/syntax/zimwiki.vim
+++ b/syntax/zimwiki.vim
@@ -14,6 +14,7 @@ syn match zimwikiHeader4 '^=\{3} .\+ =\{3}[[:space:]]*$'
 syn match zimwikiHeader5 '^=\{2} .\+ =\{2}[[:space:]]*$'
 
 syn match zimwikiLink '\[\[.\{-1,}\]\]'
+
 syn match zimwikiListItem '^[[:blank:]]*\* .\+'
 syn match zimwikiCheckbox '\[[ \*x]\]'
 syn match zimwikiStrong '\*\*.\{-1,}\*\*'
@@ -24,6 +25,7 @@ syn match zimwikiStrikeThrough '\~\~.\{-1,}\~\~'
 syn match zimwikiImage '{{.\{-1,}}}'
 syn match zimwikiSub '_{.\{-1,}}'
 syn match zimwikiSup '\^{.\{-1,}}'
+syn match zimwikiTag '\k\@<!@\k\S*' containedin=zimwikiListItem
 
 syn region zimwikiCode start="'''" end="'''"
 
@@ -45,6 +47,9 @@ hi def link zimwikiStrikeThrough	Comment
 hi def link zimwikiImage	Float
 hi def link zimwikiSub	Number
 hi def link zimwikiSup	Number
+" hi! def link zimwikiTag Number
+hi! def link zimwikiTag PreProc
+
 
 hi def link zimwikiCode	SpecialComment
 


### PR DESCRIPTION
Tags are supported in Zim wiki as per the following syntax:  @tag, see: [https://zim-wiki.org/manual/Help/Tags.html](url).

This pull request allows syntax highlighting of tags with the PreProc on their own as well as in conjunction with list items and text lines. 

![image](https://user-images.githubusercontent.com/199408/132931070-1138dfae-6028-4e8e-8467-b8a750750176.png)
